### PR TITLE
mark code block as gherkin

### DIFF
--- a/knpu/episode1/application-problem.rst
+++ b/knpu/episode1/application-problem.rst
@@ -79,6 +79,8 @@ Setting the Content-Type Header
 But even still, we want people to know our error response is using this media
 type. First, let's update the test to look for this ``Content-Type`` header:
 
+.. code-block:: gherkin
+
     # features/api/programmer.feature
     # ...
 


### PR DESCRIPTION
right now it looks like a quote and when copying the code the quote sings are "wrong".